### PR TITLE
Add intensity clamp even if N3 isn't run to account for resampling

### DIFF
--- a/progs/nuc_inorm_stage
+++ b/progs/nuc_inorm_stage
@@ -149,7 +149,11 @@ if ( -e $input ) {
     # This is ugly! Clear minc history to avoid a bug in netCDF-3.6.1 (see Claude)
     &run( "minc_modify_header", "-sinsert", ":history=\"\"", $output );
   } else {
-    &run( 'ln', '-sf', $input, $output );
+    # Still need to clamp the output if N3 is not run to account for sinc or tricubic negative values
+    my $top;
+    chomp($top = `mincstats -quiet -max $input`);
+    my $clip_expr = "if(A[0]<0){out=0;}else{if(A[0]>${top}){out=${top};}else{out=A[0];}}";
+    &run( "minccalc", "-clobber", "-expression", $clip_expr, $input, $output );
   }
 }
 


### PR DESCRIPTION
If CIVET is run with N3 distance = 0 to skip that stage *and* -interp sinc or -interp cubic is used, negative values make it through to further stages, likely causing numerical instability problems. Clamp 0-max in the nuc stage even if not run.